### PR TITLE
Fix relative path error in setup.py

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -4,4 +4,4 @@ on:
   pull_request:
 jobs:
   license_tests:
-    uses: neongeckocom/.github/.github/workflows/license_tests.yml@FEAT_UpdateLicenseTests
+    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -4,4 +4,4 @@ on:
   pull_request:
 jobs:
   license_tests:
-    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
+    uses: neongeckocom/.github/.github/workflows/license_tests.yml@FEAT_UpdateLicenseTests

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     author_email='developers@neon.ai',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_dir={SKILL_PKG: ""},
+    package_dir={SKILL_PKG: BASE_PATH},
     packages=[SKILL_PKG, f"{SKILL_PKG}.skill"],
     package_data={SKILL_PKG: find_resource_files()},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ setup(
     author_email='developers@neon.ai',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    package_dir={SKILL_PKG: ".", f"{SKILL_PKG}.skill": "skill"},
+    packages=[SKILL_PKG, f"{SKILL_PKG}.skill"],
     package_data={SKILL_PKG: find_resource_files()},
     include_package_data=True,
     entry_points={"ovos.plugin.skill": PLUGIN_ENTRY_POINT}

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from os import getenv, path, walk
 
 SKILL_NAME = "skill-weather"
@@ -93,8 +93,7 @@ setup(
     author_email='developers@neon.ai',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_dir={SKILL_PKG: "."},
-    packages=[SKILL_PKG, f"{SKILL_PKG}.skill"],
+    packages=find_packages(),
     package_data={SKILL_PKG: find_resource_files()},
     include_package_data=True,
     entry_points={"ovos.plugin.skill": PLUGIN_ENTRY_POINT}

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     author_email='developers@neon.ai',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_dir={SKILL_PKG: BASE_PATH},
+    package_dir={SKILL_PKG: "."},
     packages=[SKILL_PKG, f"{SKILL_PKG}.skill"],
     package_data={SKILL_PKG: find_resource_files()},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,7 @@ setup(
     author_email='developers@neon.ai',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_dir={SKILL_PKG: ".", f"{SKILL_PKG}.skill": "skill"},
-    packages=[SKILL_PKG, f"{SKILL_PKG}.skill"],
+    packages=find_packages(where=path.dirname(__file__) or "."),
     package_data={SKILL_PKG: find_resource_files()},
     include_package_data=True,
     entry_points={"ovos.plugin.skill": PLUGIN_ENTRY_POINT}

--- a/skill.json
+++ b/skill.json
@@ -1,6 +1,6 @@
 {
     "title": "Weather",
-    "url": "https://github.com/NeonDmitry/skill-weather",
+    "url": "https://github.com/NeonGeckoCom/skill-weather",
     "summary": "Get current weather and forecast info.",
     "short_description": "Get current weather and forecast info.",
     "description": "This skill provides current weather information at different locations and forecasts up to 5 days. Use of this skill requires use of third-party APIs. If you do not have access to Neon API servers, you may access the Alpha Vantage API directly by providing a key in `~/owm.txt`. You can generate an Open Weather Map key [here](https://home.openweathermap.org/users/sign_up)",
@@ -42,7 +42,7 @@
         "reginaneon"
     ],
     "skillname": "skill-weather",
-    "authorname": "NeonDmitry",
+    "authorname": "NeonGeckoCom",
     "foldername": null,
     "troubleshooting": "Try asking for a different location or changing your default location by saying `Neon change my location to Seattle`."
 }


### PR DESCRIPTION
# Description
In practice, automation does not appear to ever fail due to this error, but the relative build tests are logging/annotating errors due to a missed relative path in `setup.py`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->